### PR TITLE
fix: deploy to gh-pages branch instead of Pages API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,16 +8,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,21 +29,9 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: '.output/public'
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .output/public
+          publish_branch: gh-pages


### PR DESCRIPTION
The repository's GitHub Pages is configured to serve from the gh-pages branch, not via the Pages API. Switch to using peaceiris/actions-gh-pages to push built output to gh-pages.

https://claude.ai/code/session_01QRqawYS6dbenMCAqUQcWvf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks the GitHub Pages workflow to publish directly to the `gh-pages` branch using `peaceiris/actions-gh-pages`.
> 
> - Replaces Pages API steps (`configure-pages`, artifact upload, and `actions/deploy-pages`) with a single deploy step pushing `.output/public` to `gh-pages`
> - Consolidates into one `build-and-deploy` job and grants `contents: write` permission
> - Keeps Node 22 build steps (`npm ci`, `npm run build`) unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23b87ee79a72c3ecb6adef826b63097f47e9d7bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->