### PR TITLE
Add Markdown file preview with rendered and source view toggle

### DIFF
--- a/public/unzip/index.html
+++ b/public/unzip/index.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.jsdelivr.net/npm/file-type-mime@0.4.7/dist/index.umd.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.1/marked.min.js"></script>
     <style>
 
         * {
@@ -591,6 +592,148 @@
             transform: translateX(-50%) translateY(0);
             opacity: 1;
         }
+
+        /* Markdown 渲染预览 */
+        .markdown-preview {
+            padding: 1.5rem;
+            line-height: 1.7;
+            color: var(--text-primary);
+            font-size: 0.9375rem;
+            overflow-wrap: break-word;
+        }
+
+        .markdown-preview h1, .markdown-preview h2, .markdown-preview h3,
+        .markdown-preview h4, .markdown-preview h5, .markdown-preview h6 {
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+            font-weight: 600;
+            line-height: 1.3;
+            color: var(--text-primary);
+        }
+
+        .markdown-preview h1 { font-size: 2em; border-bottom: 1px solid var(--border); padding-bottom: 0.3em; }
+        .markdown-preview h2 { font-size: 1.5em; border-bottom: 1px solid var(--border); padding-bottom: 0.3em; }
+        .markdown-preview h3 { font-size: 1.25em; }
+        .markdown-preview h4 { font-size: 1em; }
+
+        .markdown-preview p { margin-bottom: 1em; }
+
+        .markdown-preview a {
+            color: var(--accent-light);
+            text-decoration: none;
+        }
+
+        .markdown-preview a:hover { text-decoration: underline; }
+
+        .markdown-preview code {
+            background: var(--bg-secondary);
+            padding: 0.2em 0.4em;
+            border-radius: 0.25rem;
+            font-size: 0.875em;
+            font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+        }
+
+        .markdown-preview pre {
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            overflow-x: auto;
+            margin-bottom: 1em;
+        }
+
+        .markdown-preview pre code {
+            background: transparent;
+            padding: 0;
+            font-size: 0.8125rem;
+            line-height: 1.6;
+        }
+
+        .markdown-preview blockquote {
+            border-left: 4px solid var(--accent);
+            padding: 0.5em 1em;
+            margin: 0 0 1em 0;
+            color: var(--text-secondary);
+            background: rgba(59, 130, 246, 0.05);
+            border-radius: 0 0.25rem 0.25rem 0;
+        }
+
+        .markdown-preview blockquote p:last-child { margin-bottom: 0; }
+
+        .markdown-preview ul, .markdown-preview ol {
+            padding-left: 1.5em;
+            margin-bottom: 1em;
+        }
+
+        .markdown-preview li { margin-bottom: 0.25em; }
+
+        .markdown-preview li > ul, .markdown-preview li > ol { margin-bottom: 0; }
+
+        .markdown-preview table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1em;
+        }
+
+        .markdown-preview th, .markdown-preview td {
+            border: 1px solid var(--border);
+            padding: 0.5em 0.75em;
+            text-align: left;
+        }
+
+        .markdown-preview th {
+            background: var(--bg-secondary);
+            font-weight: 600;
+        }
+
+        .markdown-preview tr:nth-child(even) { background: rgba(30, 41, 59, 0.3); }
+
+        .markdown-preview img {
+            max-width: 100%;
+            border-radius: 0.5rem;
+        }
+
+        .markdown-preview hr {
+            border: none;
+            border-top: 1px solid var(--border);
+            margin: 1.5em 0;
+        }
+
+        .markdown-preview input[type="checkbox"] {
+            margin-right: 0.5em;
+        }
+
+        /* 视图切换按钮 */
+        .view-toggle {
+            display: inline-flex;
+            border-radius: 0.375rem;
+            overflow: hidden;
+            border: 1px solid var(--border);
+            margin-left: 0.5rem;
+            flex-shrink: 0;
+        }
+
+        .view-toggle-btn {
+            background: none;
+            border: none;
+            color: var(--text-secondary);
+            cursor: pointer;
+            padding: 0.35rem 0.625rem;
+            font-size: 0.75rem;
+            font-weight: 500;
+            transition: all 0.2s;
+            white-space: nowrap;
+        }
+
+        .view-toggle-btn:hover {
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--text-primary);
+        }
+
+        .view-toggle-btn.active {
+            background: var(--accent);
+            color: white;
+        }
     </style>
 </head>
 <body>
@@ -671,6 +814,7 @@
         let currentFile = null;
         let pathStack = [];
         let currentFileContent = null;
+        let currentMarkdownView = 'rendered'; // 'rendered' or 'source'
 
         const fileTypeParser = window.fileTypeMime;
 
@@ -941,6 +1085,11 @@
             return mimeType && mimeType.startsWith('video/');
         }
 
+        function isMarkdownFile(filename) {
+            const ext = filename.split('.').pop().toLowerCase();
+            return ['md', 'markdown', 'mdown', 'mkd', 'mkdn'].includes(ext);
+        }
+
         function getHighlightLanguage(filename, mimeType) {
             const ext = filename.split('.').pop().toLowerCase();
             const languageMap = {
@@ -1046,19 +1195,25 @@
                 } else if (isTextType(mimeType) || fileItem._file._data.uncompressedSize < 1024 * 1024) {
                     const content = new TextDecoder('utf-8', { fatal: false }).decode(arrayBuffer);
                     currentFileContent = content;
-                    
-                    const language = getHighlightLanguage(fileItem._name, mimeType);
-                    
-                    document.getElementById('previewContent').innerHTML = `
-                        <div class="code-preview">
-                            <pre><code class="language-${language}">${escapeHtml(content)}</code></pre>
-                        </div>
-                    `;
-                    
-                    document.querySelectorAll('pre code').forEach((block) => {
-                        hljs.highlightElement(block);
-                    });
-                    
+
+                    if (isMarkdownFile(fileItem._name)) {
+                        currentMarkdownView = 'rendered';
+                        renderMarkdownPreview(content, fileItem._name);
+                        addMarkdownToggle(content, fileItem._name);
+                    } else {
+                        const language = getHighlightLanguage(fileItem._name, mimeType);
+
+                        document.getElementById('previewContent').innerHTML = `
+                            <div class="code-preview">
+                                <pre><code class="language-${language}">${escapeHtml(content)}</code></pre>
+                            </div>
+                        `;
+
+                        document.querySelectorAll('pre code').forEach((block) => {
+                            hljs.highlightElement(block);
+                        });
+                    }
+
                     addCopyButton();
                     addDownloadButton();
                     
@@ -1127,6 +1282,64 @@
             `;
             downloadBtn.onclick = downloadCurrentFile;
             actions.appendChild(downloadBtn);
+        }
+
+        function renderMarkdownPreview(content, filename) {
+            const previewContent = document.getElementById('previewContent');
+
+            if (currentMarkdownView === 'rendered') {
+                const renderer = new marked.Renderer();
+                marked.setOptions({
+                    renderer: renderer,
+                    breaks: true,
+                    gfm: true
+                });
+
+                const htmlContent = marked.parse(content);
+                previewContent.innerHTML = `<div class="markdown-preview">${htmlContent}</div>`;
+
+                // 对渲染后的代码块应用语法高亮
+                previewContent.querySelectorAll('pre code').forEach((block) => {
+                    hljs.highlightElement(block);
+                });
+            } else {
+                const language = getHighlightLanguage(filename, null);
+                previewContent.innerHTML = `
+                    <div class="code-preview">
+                        <pre><code class="language-${language}">${escapeHtml(content)}</code></pre>
+                    </div>
+                `;
+                previewContent.querySelectorAll('pre code').forEach((block) => {
+                    hljs.highlightElement(block);
+                });
+            }
+        }
+
+        function addMarkdownToggle(content, filename) {
+            const actions = document.getElementById('previewActions');
+
+            const toggle = document.createElement('div');
+            toggle.className = 'view-toggle';
+            toggle.innerHTML = `
+                <button class="view-toggle-btn ${currentMarkdownView === 'rendered' ? 'active' : ''}" data-view="rendered">预览</button>
+                <button class="view-toggle-btn ${currentMarkdownView === 'source' ? 'active' : ''}" data-view="source">源码</button>
+            `;
+
+            toggle.querySelectorAll('.view-toggle-btn').forEach(btn => {
+                btn.onclick = () => {
+                    const view = btn.dataset.view;
+                    if (view === currentMarkdownView) return;
+                    currentMarkdownView = view;
+
+                    toggle.querySelectorAll('.view-toggle-btn').forEach(b => b.classList.remove('active'));
+                    btn.classList.add('active');
+
+                    renderMarkdownPreview(content, filename);
+                };
+            });
+
+            // 插入到 actions 最前面
+            actions.insertBefore(toggle, actions.firstChild);
         }
 
         async function copyContent() {


### PR DESCRIPTION
## Summary
This PR adds native Markdown file preview support to the ZIP file viewer with the ability to toggle between rendered and source code views.

## Key Changes
- **Added marked.js library** - Integrated marked.js (v12.0.1) via CDN for Markdown parsing and rendering
- **Markdown detection** - Implemented `isMarkdownFile()` function to identify Markdown files by extension (.md, .markdown, .mdown, .mkd, .mkdn)
- **Dual view modes** - Users can switch between:
  - **Rendered view**: Displays formatted Markdown with proper styling
  - **Source view**: Shows raw Markdown code with syntax highlighting
- **Comprehensive styling** - Added extensive CSS for Markdown elements including:
  - Headings with borders and proper hierarchy
  - Code blocks with syntax highlighting support
  - Blockquotes, tables, lists, and images
  - Links, horizontal rules, and checkboxes
- **View toggle UI** - Added inline toggle buttons to switch between preview and source modes
- **Smart rendering** - Markdown files are automatically detected and rendered instead of being treated as plain text

## Implementation Details
- The `renderMarkdownPreview()` function handles both rendered and source views, applying syntax highlighting to code blocks in both modes
- The `addMarkdownToggle()` function creates and manages the view toggle buttons with active state tracking
- Markdown rendering uses GitHub Flavored Markdown (GFM) with line breaks enabled for better readability
- The current view preference is stored in `currentMarkdownView` variable to maintain state during file navigation

https://claude.ai/code/session_01LQLhM7tsNNtRmKGfRMEV9A