### PR TITLE
Add front matter extraction and rendering for Markdown previews

### DIFF
--- a/public/unzip/index.html
+++ b/public/unzip/index.html
@@ -1362,6 +1362,15 @@
             actions.appendChild(downloadBtn);
         }
 
+        function extractFrontMatter(text) {
+            const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
+            if (!match) return { frontMatter: null, body: text };
+            return {
+                frontMatter: match[1],
+                body: text.slice(match[0].length)
+            };
+        }
+
         function renderMarkdownPreview(content, filename) {
             const previewContent = document.getElementById('previewContent');
 
@@ -1373,7 +1382,11 @@
                     gfm: true
                 });
 
-                const htmlContent = marked.parse(content);
+                const { frontMatter, body } = extractFrontMatter(content);
+                const fmBlock = frontMatter != null
+                    ? `<pre><code class="language-yaml">${escapeHtml(frontMatter)}</code></pre>`
+                    : '';
+                const htmlContent = fmBlock + marked.parse(body);
                 previewContent.innerHTML = `<div class="markdown-preview">${htmlContent}</div>`;
 
                 // 将 table 包裹在可滚动容器中，带阴影提示


### PR DESCRIPTION
## Summary
Enhanced the Markdown preview functionality to properly handle and display YAML front matter (metadata) commonly used in static site generators and documentation tools.

## Key Changes
- Added `extractFrontMatter()` function to parse YAML front matter blocks (delimited by `---`) from Markdown content
- Modified `renderMarkdownPreview()` to separate front matter from the document body before parsing
- Front matter is now displayed as a syntax-highlighted YAML code block above the rendered Markdown content
- The Markdown parser now only processes the body content, excluding the front matter block

## Implementation Details
- Front matter extraction uses regex pattern `/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/` to handle both Unix and Windows line endings
- Extracted front matter is escaped and wrapped in a `<pre><code>` block with `language-yaml` class for syntax highlighting
- Falls back gracefully when no front matter is present (returns null and original text as body)
- Maintains backward compatibility with Markdown files that don't contain front matter

https://claude.ai/code/session_01P3MGPPstfCxDea8aWsW9bi